### PR TITLE
Unencrypted save file support

### DIFF
--- a/BinderTool.Core/Sl2/Sl2UserData.cs
+++ b/BinderTool.Core/Sl2/Sl2UserData.cs
@@ -1,4 +1,5 @@
-﻿using System.IO;
+﻿using System;
+using System.IO;
 using System.Text;
 
 namespace BinderTool.Core.Sl2
@@ -6,24 +7,33 @@ namespace BinderTool.Core.Sl2
     public class Sl2UserData
     {
         private const int UserDataIvSize = 16;
-        
+
         private readonly byte[] _key;
 
         private readonly byte[] _iv;
+
+        private readonly bool _encrypted;
 
         public Sl2UserData(byte[] key)
         {
             _key = key;
             _iv = new byte[UserDataIvSize];
+            _encrypted = Equals(key, new byte[key.Length]) ? true : false;
         }
 
         public string Name { get; set; }
 
         public byte[] EncryptedUserData { get; private set; }
 
-        //public byte[] DecryptedUserData => CryptographyUtility.DecryptAesCbc(new MemoryStream(EncryptedUserData), _key, _iv).ToArray();
-        public byte[] DecryptedUserData => null;
+        public byte[] DecryptedUserData()
+        {
+            if (!_encrypted)
+                return EncryptedUserData;
 
+            MemoryStream ms = new MemoryStream();
+            CryptographyUtility.DecryptAesCbc(new MemoryStream(EncryptedUserData), _key, _iv).CopyTo(ms);
+            return ms.ToArray();
+        }
 
         public static Sl2UserData ReadSl2UserData(Stream inputStream, byte[] key, int size, string name)
         {

--- a/BinderTool/Program.cs
+++ b/BinderTool/Program.cs
@@ -596,7 +596,7 @@ namespace BinderTool
                 foreach (var userData in sl2File.UserData)
                 {
                     string outputFilePath = Path.Combine(options.OutputPath, userData.Name);
-                    File.WriteAllBytes(outputFilePath, userData.DecryptedUserData);
+                    File.WriteAllBytes(outputFilePath, userData.DecryptedUserData());
                 }
             }
         }


### PR DESCRIPTION
Added support for unencrypted SaveLoad2 format save files like Elden Ring.

For `DecryptedUserData` in the existing elden-ring branch, it is initialized to null.
Through this commit, the constructor of `Sl2UserData` checks whether the key exists and stores it in the newly added member `_encrypted`. 
When `DecryptedUserData` is called after parsing the sl2 file, the plaintext of the unencrypted file is saved according to the status of the `_encrypted` member. Or, if it is encrypted, proceed with AES decryption. 

I'm sorry I couldn't write better code because I didn't have deep knowledge of C#. 
If there is a better way, let's discuss it. 